### PR TITLE
use repositories from github instead of gitlab

### DIFF
--- a/conf/bblayers.conf.sample
+++ b/conf/bblayers.conf.sample
@@ -20,7 +20,6 @@ BBLAYERS ?= " \
   ##OEROOT##/meta-virtualization \
   ##OEROOT##/meta-poky \
   ##OEROOT##/meta-yocto-bsp \
-  ##OEROOT##/meta-tibit \
   "
 BBLAYERS_NON_REMOVABLE ?= " \
   ##OEROOT##/meta \

--- a/default.xml
+++ b/default.xml
@@ -14,7 +14,6 @@
   <!-- open source bisdn layers -->
   <project path="poky/bisdn-onie-additions" name="bisdn/bisdn-onie-additions.git" remote="github" revision="master" sync-s="true"/>
   <project path="poky/meta-ofdpa" name="bisdn/meta-ofdpa.git" remote="github" revision="master"/>
-  <project path="poky/meta-tibit" name="yocto-meta-layers/meta-tibit.git" remote="gitlab" revision="master"/>
   <project path="poky/build-bisdn-linux" name="bisdn/bisdn-linux.git" remote="github" revision="master"/>
   <project path="poky/meta-open-network-linux" name="bisdn/meta-open-network-linux.git" remote="github" revision="master"/>
   <project path="poky/meta-switch" name="bisdn/meta-switch.git" remote="github" revision="master"/>


### PR DESCRIPTION
* we moved everything that we can open source for our build pipeline
  from gitlab to github, this commit updates the corresponding project
  paths for the repo tool

Signed-off-by: Jan Klare <jan.klare@bisdn.de>