### PR TITLE
allow building with still closed source repos

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
-  <remote name="github" fetch="git://github.com/" />
+  <remote name="github" fetch="ssh://git@github.com/" />
   <remote name="gitlab" fetch="ssh://git@gitlab.bisdn.de/" />
   <remote name="yocto" fetch="git://git.yoctoproject.org/" />
   <remote name="oe" fetch="git://git.openembedded.org/" />


### PR DESCRIPTION
* this commit allows fetching from closed source github repos by using
  ssh instead of https
* this is only to be used as long as we have not yet open sourced all
  needed repos

Signed-off-by: Jan Klare <jan.klare@bisdn.de>