### PR TITLE
README.md update: minimum requirements, dependencies and comments on build time

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ for BISDN Linux, based on Yocto.
 
 The build process takes around 3-4 hours with 8 CPU cores and 8 GiB RAM. A single
 build requires ~70 GiB of disk space. Adding additional CPU cores speeds up the
-build time significally.
+build time significantly.
 
 ## Prerequisites
 


### PR DESCRIPTION
Added some small comments and additions.

Most vital things is a rough approximation of the space needed to build.
Mention what Ubuntu packages are missing if one builds using Ubuntu.
Added comment on where to set the cache directory in `local.conf`, and where to find the built image, as it will depend on the directory set.
