### PR TITLE
local.conf: provide default location for ccache files

### DIFF
--- a/conf/local.conf.sample
+++ b/conf/local.conf.sample
@@ -227,6 +227,12 @@ SSTATE_DIR ?= "/tmp/sstate-cache"
 TMPDIR = "/tmp/${MACHINE}"
 DL_DIR ?= "/tmp/downloads"
 
+# To enable ccache, uncomment the following line
+#INHERIT += "ccache"
+
+# ccache is sharable between different builds, so move it to a common location.
+CCACHE_TOP_DIR ?= "/tmp/ccache"
+
 #INHERIT += "rm_work"
 #RM_WORK_EXCLUDE += "linux-yocto uboot"
 #BB_NUMBER_THREADS = "8"


### PR DESCRIPTION
To allow easier sharing of ccache data, move the CCACHE_TOP_DIR from
"${TMPDIR}/ccache" to "/tmp/ccache".

Do not enable it by default, since it only provides any benefit on
rebuilds, and will actually slow down the initial build.

Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>