### PR TITLE
Revert "allow building with still closed source repos"

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
-  <remote name="github" fetch="ssh://git@github.com/" />
+  <remote name="github" fetch="git://github.com/" />
   <remote name="gitlab" fetch="ssh://git@gitlab.bisdn.de/" />
   <remote name="oe" fetch="git://git.openembedded.org/" />
   <remote name="yocto" fetch="git://git.yoctoproject.org/" />


### PR DESCRIPTION
Now that the repos are public, we can use git transport and allow
checking out without a github account.

This reverts commit c2bddb3ab6e63e10755cda63f8c49cbea29c909c.

Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>