### PR TITLE
Revert "allow building with still closed source repos"

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
-  <remote fetch="ssh://git@github.com/" name="github"/>
+  <remote fetch="git://github.com/" name="github"/>
   <remote fetch="ssh://git@gitlab.bisdn.de/" name="gitlab"/>
   <remote fetch="git://git.openembedded.org/" name="oe"/>
   <remote fetch="git://git.yoctoproject.org/" name="yocto"/>


### PR DESCRIPTION
Now that the repos are public, we can use git transport and allow
checking out without a github account.

This reverts commit c2bddb3ab6e63e10755cda63f8c49cbea29c909c.

Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
(cherry picked from commit 4deab28fd790a82e8bc7ff2e91a7957f2223c376)