### PR TITLE
add cel-questone-2a to local.conf.sample

### DIFF
--- a/conf/local.conf.sample
+++ b/conf/local.conf.sample
@@ -20,6 +20,7 @@
 #MACHINE ?= "accton-as4610"
 #MACHINE ?= "agema-ag5648"
 #MACHINE ?= "agema-ag7648"
+#MACHINE ?= "cel-questone-2a"
 #
 MACHINE ?= "accton-as4610"
 


### PR DESCRIPTION
* to make it obvious that the cel-questone-2a is a supported platform
  and can be used as MACHINE target, we add it to the local.conf.sample

Signed-off-by: Jan Klare <jan.klare@bisdn.de>