### PR TITLE
default.xml: switch git transport to https for github

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
-  <remote name="github" fetch="git://github.com/" />
+  <remote name="github" fetch="https://github.com/" />
   <remote name="gitlab" fetch="ssh://git@gitlab.bisdn.de/" />
   <remote name="oe" fetch="git://git.openembedded.org/" />
   <remote name="yocto" fetch="git://git.yoctoproject.org/" />


### PR DESCRIPTION
Github just turned off the git transport on their servers, and checking
out now fails with:

fatal: remote error:
  The unauthenticated git protocol on port 9418 is no longer supported.
Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.

So switch to https to make stuff build again.

Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>