### PR TITLE
conf: set release FEEDURIPREFIX

### DIFF
--- a/conf/local.conf.sample
+++ b/conf/local.conf.sample
@@ -245,3 +245,6 @@ CCACHE_TOP_DIR ?= "/tmp/ccache"
 #RM_WORK_EXCLUDE += "linux-yocto uboot"
 #BB_NUMBER_THREADS = "8"
 #PARALLEL_MAKE = "-j16"
+
+# Packages base path for release
+FEEDURIPREFIX = "pub/onie/${MACHINE}/packages-v${DISTRO_VERSION}"


### PR DESCRIPTION
Set the FEEDURIPREFIX to the release path.

Signed-off-by: hilmar.magnusson <hilmar.magnusson@bisdn.de>