### PR TITLE
switch to yocto kirkstone (4.0)

### DIFF
--- a/conf/local.conf.sample
+++ b/conf/local.conf.sample
@@ -223,7 +223,7 @@ BB_DISKMON_DIRS = "\
 # CONF_VERSION is increased each time build/conf/ changes incompatibly and is used to
 # track the version of this file when it was generated. This can safely be ignored if
 # this doesn't mean anything to you.
-CONF_VERSION = "1"
+CONF_VERSION = "2"
 
 SSTATE_DIR ?= "/tmp/sstate-cache"
 TMPDIR = "/tmp/${MACHINE}"

--- a/conf/local.conf.sample
+++ b/conf/local.conf.sample
@@ -137,12 +137,11 @@ PACKAGE_CLASSES ?= "package_ipk"
 # enable extra features. Some available options which can be included in this variable
 # are:
 #   - 'buildstats' collect build statistics
-#   - 'image-mklibs' to reduce shared library files size for an image
 #   - 'image-prelink' in order to prelink the filesystem image
 #   - 'image-swab' to perform host system intrusion detection
 # NOTE: if listing mklibs & prelink both, then make sure mklibs is before prelink
 # NOTE: mklibs also needs to be explicitly enabled for a given image, see local.conf.extended
-USER_CLASSES ?= "buildstats image-mklibs image-prelink"
+USER_CLASSES ?= "buildstats image-prelink"
 
 #
 # Runtime testing of images

--- a/conf/local.conf.sample
+++ b/conf/local.conf.sample
@@ -137,11 +137,10 @@ PACKAGE_CLASSES ?= "package_ipk"
 # enable extra features. Some available options which can be included in this variable
 # are:
 #   - 'buildstats' collect build statistics
-#   - 'image-prelink' in order to prelink the filesystem image
 #   - 'image-swab' to perform host system intrusion detection
 # NOTE: if listing mklibs & prelink both, then make sure mklibs is before prelink
 # NOTE: mklibs also needs to be explicitly enabled for a given image, see local.conf.extended
-USER_CLASSES ?= "buildstats image-prelink"
+USER_CLASSES ?= "buildstats"
 
 #
 # Runtime testing of images

--- a/conf/local.conf.sample
+++ b/conf/local.conf.sample
@@ -184,10 +184,10 @@ BB_DISKMON_DIRS = "\
     STOPTASKS,${DL_DIR},1G,100K \
     STOPTASKS,${SSTATE_DIR},1G,100K \
     STOPTASKS,/tmp,100M,100K \
-    ABORT,${TMPDIR},100M,1K \
-    ABORT,${DL_DIR},100M,1K \
-    ABORT,${SSTATE_DIR},100M,1K \
-    ABORT,/tmp,10M,1K"
+    HALT,${TMPDIR},100M,1K \
+    HALT,${DL_DIR},100M,1K \
+    HALT,${SSTATE_DIR},100M,1K \
+    HALT,/tmp,10M,1K"
 
 #
 # Shared-state files from other locations

--- a/default.xml
+++ b/default.xml
@@ -5,11 +5,11 @@
   <remote name="oe" fetch="git://git.openembedded.org/" />
   <remote name="yocto" fetch="git://git.yoctoproject.org/" />
   <!-- yocto layer -->
-  <project name="meta-cloud-services" path="poky/meta-cloud-services" remote="yocto" revision="dunfell"/>
-  <project name="meta-virtualization" path="poky/meta-virtualization" remote="yocto" revision="dunfell"/>
-  <project name="poky" path="poky" remote="yocto" revision="dunfell"/>
+  <project name="meta-cloud-services" path="poky/meta-cloud-services" remote="yocto" revision="kirkstone"/>
+  <project name="meta-virtualization" path="poky/meta-virtualization" remote="yocto" revision="kirkstone"/>
+  <project name="poky" path="poky" remote="yocto" revision="kirkstone"/>
   <!-- open embedded layer -->
-  <project name="meta-openembedded" path="poky/meta-openembedded" remote="oe" revision="dunfell"/>
+  <project name="meta-openembedded" path="poky/meta-openembedded" remote="oe" revision="kirkstone"/>
   <!-- open source bisdn layers -->
   <project name="bisdn/bisdn-linux.git" path="poky/build-bisdn-linux" remote="github" revision="master"/>
   <project name="bisdn/bisdn-onie-additions.git" path="poky/bisdn-onie-additions" remote="github" revision="master"/>

--- a/extra/tibit.xml
+++ b/extra/tibit.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<manifest>
-  <project name="yocto-meta-layers/meta-tibit.git" path="poky/meta-tibit" remote="gitlab" revision="master"/>
-</manifest>


### PR DESCRIPTION
Switch to Yocto Kirkstone (4.0), the newest LTS release.

Brings proper Linux 5.15 support, newer everything and plenty of improvements and changes.

Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>