### PR TITLE
default.xml: drop now unused bisdn-onie-additions

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -12,7 +12,6 @@
   <project name="meta-openembedded" path="poky/meta-openembedded" remote="oe" revision="kirkstone"/>
   <!-- open source bisdn layers -->
   <project name="bisdn/bisdn-linux.git" path="poky/build-bisdn-linux" remote="github" revision="master"/>
-  <project name="bisdn/bisdn-onie-additions.git" path="poky/bisdn-onie-additions" remote="github" revision="master"/>
   <project name="bisdn/meta-ofdpa.git" path="poky/meta-ofdpa" remote="github" revision="master"/>
   <project name="bisdn/meta-open-network-linux.git" path="poky/meta-open-network-linux" remote="github" revision="master"/>
   <project name="bisdn/meta-switch.git" path="poky/meta-switch" remote="github" revision="master"/>


### PR DESCRIPTION
Since we moved all required files to meta-switch, we do not need
bisdn-onie-additions anymore and can drop it from the checkout.

Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>