### PR TITLE
default.xml: replace extra manifests with groups

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -15,4 +15,6 @@
   <project name="bisdn/meta-ofdpa.git" path="poky/meta-ofdpa" remote="github" revision="master"/>
   <project name="bisdn/meta-open-network-linux.git" path="poky/meta-open-network-linux" remote="github" revision="master"/>
   <project name="bisdn/meta-switch.git" path="poky/meta-switch" remote="github" revision="master"/>
+  <!-- closed source bisdn layers -->
+  <project name="yocto-meta-layers/meta-ofdpa.git" path="poky/meta-ofdpa-closed" remote="gitlab" revision="master" groups="notdefault,ofdpa-gitlab"/>
 </manifest>

--- a/extra/README.md
+++ b/extra/README.md
@@ -1,3 +1,0 @@
-Optional layers for internal development.
-
-These won't work if you do not have access to the closed source gitlab repositories.

--- a/extra/ofdpa-gitlab.xml
+++ b/extra/ofdpa-gitlab.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<manifest>
-  <remove-project name="bisdn/meta-ofdpa.git" />
-  <project name="yocto-meta-layers/meta-ofdpa.git" path="poky/meta-ofdpa" remote="gitlab" revision="master"/>
-</manifest>


### PR DESCRIPTION
Replace the external extra manifests files with additional projects in
the default.xml, assigned to non-default groups.

To avoid the internal project being checked out by default, add it to
the special group "notdefault", which prevents it from being added to
the default "all" group.

This allows having all projects in one place. Repo requires all projects
to have unique paths, so we cannot replace the open source one, but need
to use it as an additional layer. Therefore check it out as
meta-ofdpa-closed.

This requires additional changes to the internal meta-ofdpa repo to
allow coexistence with the open one to avoid name collisions.

This way the repository can be initialized as normal via

    repo init -b master -u ...

and for the internal development variant

    repo init -b master -u ... -g all,ofdpa-gitlab

Note that you must include the all group, else you will only get the
projects from the ofdpa-gitlab group.

Also since yocto does not support auto-detection of layers, you will
then need to add the closed layer manually via

    bitbake-layers add-layer <pathtolayer>

The advantage of this is that the generated release default.xml will
then contain fixed revisions for all checked out projects, including the
internal one when checked as well.

Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>