### PR TITLE
include a list of fixed CVEs in changelogs

### DIFF
--- a/conf/local.conf.sample
+++ b/conf/local.conf.sample
@@ -237,6 +237,9 @@ DL_DIR ?= "/tmp/downloads"
 # ccache is sharable between different builds, so move it to a common location.
 CCACHE_TOP_DIR ?= "/tmp/ccache"
 
+# To enable CVE checking, uncomment the following line
+#INHERIT += "cve-check"
+
 #INHERIT += "rm_work"
 #RM_WORK_EXCLUDE += "linux-yocto uboot"
 #BB_NUMBER_THREADS = "8"

--- a/scripts/prepare_release.sh
+++ b/scripts/prepare_release.sh
@@ -82,7 +82,7 @@ sanity_check_meta-ofdpa() {
 generate_changelog() {
 	echo "Generating changelog (this may take a while) ..."
 
-	$TOPDIR/scripts/changelog.sh -w $WORKDIR -n $NEW -i meta-ofdpa-closed $OLD "$RELEASE_BRANCH" > changelog.txt
+	$TOPDIR/scripts/changelog.sh -f -w $WORKDIR -n $NEW -i meta-ofdpa-closed $OLD "$RELEASE_BRANCH" > changelog.txt
 	git add changelog.txt
 
 	if [ "$UPDATE" -eq 1 ]; then


### PR DESCRIPTION
Add a new flag for calculating fixed CVEs between two versions, and use this for the changelog for new releases.

This works by getting open CVEs for each package included in the image,
then comparing the lists.

Creates output like this:

```
  Fixed CVEs:
  c-ares:
    CVE-2023-31124 CVE-2023-31130 CVE-2023-31147 CVE-2023-32067

  dbus:
    CVE-2023-34969

  docker-ce:
    CVE-2023-28840 CVE-2023-28841 CVE-2023-28842
```

Be aware that the check is rather slow due to rate limiting by the CVE
database.

The CVE lists are generated based on the known CVEs at changelog generation, not time of the release, so they are not "reproducible".

As an addition, slightly extend the example config with a section explaining how to enable CVE checking for the build.