### PR TITLE
add kas project configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,10 @@
 bitbake.lock
+build
 cache
 conf/bblayers.conf
 conf/local.conf
 conf/sanity_info
-tmp
-sstate-cache
 downloads
+poky
+sstate-cache
+tmp

--- a/bisdn-linux.yaml
+++ b/bisdn-linux.yaml
@@ -1,0 +1,77 @@
+header:
+    version: 14
+distro: bisdn-linux
+build_system: oe
+machine: generic-armel-iproc
+target: full
+
+local_conf_header:
+    default-local-conf: |
+        CONF_VERSION = "2"
+        PACKAGE_CLASSES ?= "package_ipk"
+        USER_CLASSES ?= "buildstats"
+        PATCHRESOLVE = "noop"
+        BB_DISKMON_DIRS = "\
+            STOPTASKS,${TMPDIR},1G,100K \
+            STOPTASKS,${DL_DIR},1G,100K \
+            STOPTASKS,${SSTATE_DIR},1G,100K \
+            STOPTASKS,/tmp,100M,100K \
+            HALT,${TMPDIR},100M,1K \
+            HALT,${DL_DIR},100M,1K \
+            HALT,${SSTATE_DIR},100M,1K \
+            HALT,/tmp,10M,1K"
+
+repos:
+    # Yocto base (must come first)
+    poky:
+        url: "git://git.yoctoproject.org/poky"
+        branch: "kirkstone"
+        path: "poky"
+        layers:
+            meta:
+            meta-poky:
+            meta-yocto-bsp:
+
+    # additional yocto layers
+    meta-cloud-services:
+        url: "git://git.yoctoproject.org/meta-cloud-services"
+        branch: "kirkstone"
+        path: "poky/meta-cloud-services"
+        layers:
+            .:
+            meta-openstack:
+
+    meta-virtualization:
+        url: "git://git.yoctoproject.org/meta-virtualization"
+        branch: "kirkstone"
+        path: "poky/meta-virtualization"
+
+    # open embedded layers
+    meta-openembedded:
+        url: "git://git.openembedded.org/meta-openembedded"
+        branch: "kirkstone"
+        path: "poky/meta-openembedded"
+        layers:
+            meta-filesystems:
+            meta-networking:
+            meta-oe:
+            meta-python:
+            meta-webserver:
+
+    # open source BISDN layers
+    meta-bisdn-linux:
+        url: "https://github.com/bisdn/meta-bisdn-linux.git"
+        branch: "main"
+        path: "poky/meta-bisdn-linux"
+
+    meta-ofdpa:
+        url: "https://github.com/bisdn/meta-ofdpa.git"
+        branch: "main"
+        path: "poky/meta-ofdpa"
+
+    meta-open-network-linux:
+        url: "https://github.com/bisdn/meta-open-network-linux.git"
+        branch: "main"
+        path: "poky/meta-open-network-linux"
+
+

--- a/ofdpa-gitlab.yaml
+++ b/ofdpa-gitlab.yaml
@@ -1,0 +1,8 @@
+header:
+    version: 14
+
+repos:
+    meta-ofdpa-closed:
+        url: "ssh://git@gitlab.bisdn.de/yocto-meta-layers/meta-ofdpa.git"
+        branch: "main"
+        path: "poky/meta-ofdpa-closed"

--- a/release.yaml
+++ b/release.yaml
@@ -1,0 +1,6 @@
+header:
+    version: 14
+
+local_conf_header:
+    release-local-conf: |
+        FEEDURIPREFIX = "pub/onie/${MACHINE}/packages-v${DISTRO_VERSION}"

--- a/scripts/convert.sh
+++ b/scripts/convert.sh
@@ -1,0 +1,105 @@
+#!/bin/bash
+
+TOPDIR="$(git rev-parse --show-toplevel)"
+
+declare -A REPOS
+
+read_lockfile() {
+	REPOS["meta-bisdn-linux"]=$(cat $1 | yq -r '.overrides.repos."meta-bisdn-linux".commit')
+	REPOS["meta-cloud-services"]=$(cat $1 | yq -r '.overrides.repos."meta-cloud-services".commit')
+	REPOS["meta-ofdpa"]=$(cat $1 | yq -r '.overrides.repos."meta-ofdpa".commit')
+	REPOS["meta-ofdpa-closed"]=$(cat $1 | yq -r '.overrides.repos."meta-ofdpa-closed".commit')
+	REPOS["meta-open-network-linux"]=$(cat $1 | yq -r '.overrides.repos."meta-open-network-linux".commit')
+	REPOS["meta-openembedded"]=$(cat $1 | yq -r '.overrides.repos."meta-openembedded".commit')
+	REPOS["meta-virtualization"]=$(cat $1 | yq -r '.overrides.repos."meta-virtualization".commit')
+	REPOS["poky"]=$(cat $1 | yq -r '.overrides.repos."poky".commit')
+}
+
+write_lockfile() {
+	VERSION=$(cat ${TOPDIR}/bisdn-linux.yaml | yq -r '.header.version')
+	cat >$1 << EOF
+header:
+    version: ${VERSION}
+overrides:
+    repos:
+        meta-bisdn-linux:
+            commit: ${REPOS["meta-bisdn-linux"]}
+        meta-cloud-services:
+            commit: ${REPOS["meta-cloud-services"]}
+        meta-ofdpa:
+            commit: ${REPOS["meta-ofdpa"]}
+        meta-ofdpa-closed:
+            commit: ${REPOS["meta-ofdpa-closed"]}
+        meta-open-network-linux:
+            commit: ${REPOS["meta-open-network-linux"]}
+        meta-openembedded:
+            commit: ${REPOS["meta-openembedded"]}
+        meta-virtualization:
+            commit: ${REPOS["meta-virtualization"]}
+        poky:
+            commit: ${REPOS["poky"]}
+EOF
+}
+
+read_manifest() {
+	REPOS["bisdn-linux"]=$(xmlstarlet select -t -v  "/manifest/project[@name='bisdn/bisdn-linux.git']/@revision" $1)
+	REPOS["meta-bisdn-linux"]=$(xmlstarlet select -t -v  "/manifest/project[@name='bisdn/meta-bisdn-linux.git']/@revision" $1)
+	REPOS["meta-cloud-services"]=$(xmlstarlet select -t -v  "/manifest/project[@name='meta-cloud-services']/@revision" $1)
+	REPOS["meta-ofdpa"]=$(xmlstarlet select -t -v  "/manifest/project[@name='bisdn/meta-ofdpa.git']/@revision" $1)
+	REPOS["meta-ofdpa-closed"]=$(xmlstarlet select -t -v  "/manifest/project[@name='yocto-meta-layers/meta-ofdpa.git']/@revision" $1)
+	REPOS["meta-open-network-linux"]=$(xmlstarlet select -t -v  "/manifest/project[@name='bisdn/meta-open-network-linux.git']/@revision" $1)
+	REPOS["meta-openembedded"]=$(xmlstarlet select -t -v  "/manifest/project[@name='meta-openembedded']/@revision" $1)
+	REPOS["meta-virtualization"]=$(xmlstarlet select -t -v  "/manifest/project[@name='meta-virtualization']/@revision" $1)
+	REPOS["poky"]=$(xmlstarlet select -t -v  "/manifest/project[@name='poky']/@revision" $1)
+}
+
+write_manifest() {
+	# KAS does not reference this repository, so take the HEAD revision
+	if [ -z "${REPOS["bisdn-linux"]}" ]; then
+		REPOS["bisdn-linux"]="$(git rev-parse HEAD)"
+	fi
+
+	if [ "$1" == "default.xml" ]; then
+		INPLACE="--inplace"
+		OUT_FILE=""
+	else
+		INPLACE=""
+		OUT_FILE=$1
+	fi
+
+	xmlstarlet edit ${INPLACE} \
+	       --update "/manifest/project[@name='bisdn/bisdn-linux.git']/@revision" --value "${REPOS["bisdn-linux"]}" \
+	       --update "/manifest/project[@name='bisdn/meta-bisdn-linux.git']/@revision" --value "${REPOS["meta-bisdn-linux"]}" \
+	       --update "/manifest/project[@name='meta-cloud-services']/@revision" --value "${REPOS["meta-cloud-services"]}" \
+	       --update "/manifest/project[@name='bisdn/meta-ofdpa.git']/@revision" --value "${REPOS["meta-ofdpa"]}" \
+	       --update "/manifest/project[@name='yocto-meta-layers/meta-ofdpa.git']/@revision" --value "${REPOS["meta-ofdpa-closed"]}" \
+	       --update "/manifest/project[@name='bisdn/meta-open-network-linux.git']/@revision" --value "${REPOS["meta-open-network-linux"]}" \
+	       --update "/manifest/project[@name='meta-openembedded']/@revision" --value "${REPOS["meta-openembedded"]}" \
+	       --update "/manifest/project[@name='meta-virtualization']/@revision" --value "${REPOS["meta-virtualization"]}" \
+	       --update "/manifest/project[@name='poky']/@revision" --value "${REPOS["poky"]}" \
+	       "${TOPDIR}/default.xml" ${OUT_FILE}
+}
+
+case "$1" in
+	*.yml)
+		read_lockfile $1
+		;;
+	*.xml)
+		read_manifest $1
+		;;
+	*)
+		exit 1
+		;;
+esac
+
+case "$2" in
+	*.yml)
+		write_lockfile $2
+		;;
+	*.xml)
+		write_manifest $2
+		;;
+	*)
+		exit 1
+		;;
+esac


### PR DESCRIPTION
Add a kas project configuration for bisdn-linux and additional snippets for building OF-DPA from source or doing development/release builds.

In contrast to repo the initial checkout must be done manually, but also kas will configure the build and add any layers automatically.

So the minimal steps for building bisdn-linux via kas are:

```
$ git clone https://github.com/bisdn/bisdn-linux.git
$ cd bisdn-linux/
$ kas build bisdn-linux.yml
```

The checkout is slightly faster:

```
$ time kas checkout bisdn-linux.yml:ofdpa-gitlab.yml
...
real	0m14,519s
user	0m35,906s
sys	0m5,031s
```

```
$ repo init -g all,ofdpa-gitlab -u https://github.com/bisdn/bisdn-linux.git
$ time repo sync
...
real	2m14,857s
user	0m50,205s
sys	0m6,116s
```

Difference to the repo configuration (from templateconf) is that TMPDIR etc are not overridden by default, since this breaks `kas-container`. `kas-container` needs to be told where directories are supposed to be, so it properly maps them into the container.

Therefore to emulate the original layout, the following exports need to be done before invoking `kas(-container):`

```
export SSTATE_DIR="/tmp/sstate-dir"
export TMPDIR="/tmp/${MACHINE}"
export DL_DIR="/tmp/downloads"
```

TODO:
- [x] add base bisdn-linux.yml
- [x] add ofdpa-gitlab.yml
- [x] add a release.yml for release configuration
- [x] ~~add a nightly.yml for nightly build configuration~~ no value of having it
- [x] update .gitignore to ignore kas created directories
- [x] ~~move TMP path modification to nightly~~ TMPDIR must not be changed via local.conf, else kas-container breaks

Open issues:
- [ ] add documentation