### PR TITLE
v5.1.x: update default.xml and release script for stable branches

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -11,10 +11,10 @@
   <!-- open embedded layer -->
   <project name="meta-openembedded" path="poky/meta-openembedded" remote="oe" revision="kirkstone"/>
   <!-- open source bisdn layers -->
-  <project name="bisdn/bisdn-linux.git" path="poky/build-bisdn-linux" remote="github" revision="main"/>
-  <project name="bisdn/meta-ofdpa.git" path="poky/meta-ofdpa" remote="github" revision="main"/>
-  <project name="bisdn/meta-open-network-linux.git" path="poky/meta-open-network-linux" remote="github" revision="main"/>
-  <project name="bisdn/meta-switch.git" path="poky/meta-switch" remote="github" revision="main"/>
+  <project name="bisdn/bisdn-linux.git" path="poky/build-bisdn-linux" remote="github" revision="v5.1.x"/>
+  <project name="bisdn/meta-ofdpa.git" path="poky/meta-ofdpa" remote="github" revision="v5.1.x"/>
+  <project name="bisdn/meta-open-network-linux.git" path="poky/meta-open-network-linux" remote="github" revision="v5.1.x"/>
+  <project name="bisdn/meta-switch.git" path="poky/meta-switch" remote="github" revision="v5.1.x"/>
   <!-- closed source bisdn layers -->
-  <project name="yocto-meta-layers/meta-ofdpa.git" path="poky/meta-ofdpa-closed" remote="gitlab" revision="main" groups="notdefault,ofdpa-gitlab"/>
+  <project name="yocto-meta-layers/meta-ofdpa.git" path="poky/meta-ofdpa-closed" remote="gitlab" revision="v5.1.x" groups="notdefault,ofdpa-gitlab"/>
 </manifest>

--- a/scripts/prepare_release.sh
+++ b/scripts/prepare_release.sh
@@ -3,7 +3,7 @@
 set -e
 
 TOPDIR="$(git rev-parse --show-toplevel)"
-BASEBRANCH="main"
+BASEBRANCH="v5.1.x"
 BRANCHPREFIX="release"
 UPDATE=0
 


### PR DESCRIPTION
Update the default.xml and release script to use this branch and the stable branches in all meta-layers named the same (which are initialized based on the v5.1.0 release).

All Yocto/OE layers are kept at HEAD of their respective branches, to keep receiving upstream fixes.