### PR TITLE
conf: rename meta-switch in bblayers.conf.sample as well

### DIFF
--- a/conf/bblayers.conf.sample
+++ b/conf/bblayers.conf.sample
@@ -16,7 +16,7 @@ BBLAYERS ?= " \
   ##OEROOT##/meta-openembedded/meta-oe \
   ##OEROOT##/meta-openembedded/meta-python \
   ##OEROOT##/meta-openembedded/meta-webserver \
-  ##OEROOT##/meta-switch \
+  ##OEROOT##/meta-bisdn-linux \
   ##OEROOT##/meta-virtualization \
   ##OEROOT##/meta-poky \
   ##OEROOT##/meta-yocto-bsp \


### PR DESCRIPTION
When we renamed meta-switch, we also updated its path, so we need to update the bblayers.conf.sample as well to point to the new path.

Fixes: 2884b5e4dcc1 ("default.xml: update meta-switch => meta-bisdn-linux")