### PR TITLE
scripts: add a script for calculating a source date epoch

### DIFF
--- a/scripts/get_source_date_epoch.sh
+++ b/scripts/get_source_date_epoch.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# script for calculating the newest commit date of all sub repositories used,
+# output as a unix timestamp to be timezone/dateformat agnostic.
+
+PATHS="$(repo list -p -f)"
+
+NEWEST=0
+
+for path in $PATHS; do
+	COMMITDATE=$(git -c log.showSignature=false --git-dir "$path/.git" log -1 --pretty=%ct)
+	if [ "$COMMITDATE" -gt "$NEWEST" ]; then
+		NEWEST=$COMMITDATE
+	fi
+done
+
+echo "$NEWEST"


### PR DESCRIPTION
Now that image generation uses `BUILD_ID` instead of DATE(TIME) directly, we can start trying to use fixed `BUILD_ID`s for builds.

The simplest source for the `BUILD_ID` is using the newest commit timestamp of all sub repositories, so add a script for calculating the newest date as a unix timestamp.

This can then be easily converted to the expected format for BUILD_ID via

    date -u -d '@<timestamp>' +%Y%m%d%H%M%S

while converting a date back to a timestamp is a bit trickier.