### PR TITLE
prepare-release: fix adding site.conf to git

### DIFF
--- a/scripts/prepare_release.sh
+++ b/scripts/prepare_release.sh
@@ -99,6 +99,7 @@ set_feed_uri_prefix() {
 	mkdir -p conf
 	echo 'SCONF_VERSION = "1"' > conf/site.conf
 	echo 'FEEDURIPREFIX = "pub/onie/${MACHINE}/packages-v${DISTRO_VERSION}"' >> conf/site.conf
+	git add conf/site.conf
 	git commit -s -m "conf: set release FEEDURIPREFIX
 
 Set the FEEDURIPREFIX to the release path." conf/site.conf


### PR DESCRIPTION
conf/site.conf is a new file, so we need to add it explicitly before commit it.

Fixes: cfa0f7fe99c2 ("prepare_release: use site.conf instead of local.conf")