### PR TITLE
README.md: always be explicit about MACHINE

### DIFF
--- a/BUILDING_DETAILS.md
+++ b/BUILDING_DETAILS.md
@@ -2,6 +2,9 @@
 
 This document covers details that may be useful to some users.
 
+All examples build for `generic-x86-64`. Replace it with
+`generic-armel-iproc` when building for ARM.
+
 ## Building additional yocto packages
 
 Assuming the packages you want to add are already present in one of the
@@ -19,7 +22,7 @@ local_conf_header:
     extra_packages: |
         IMAGE_INSTALL:append = "iperf3 strongswan"
 EOF
-$ kas build bisdn-linux.yaml:custom-configuration.yaml
+$ KAS_MACHINE=generic-x86-64 kas build bisdn-linux.yaml:custom-configuration.yaml
 ```
 
 For packages in other layer repos, you need to add the repos first. The repos
@@ -49,7 +52,7 @@ packages and then run kas:
 ```shell
 sudo apt-get install --no-install-recommends \
   build-essential chrpath diffstat lz4
-kas build bisdn-linux.yaml
+KAS_MACHINE=generic-x86-64 kas build bisdn-linux.yaml
 ```
 
 ## Building under disk space constraints
@@ -67,7 +70,7 @@ after a package has been successfully built which reduces the amount
 of disk space required substantially:
 
 ```shell
-kas-container build bisdn-linux.yaml:rm-work.yaml
+KAS_MACHINE=generic-x86-64 kas-container build bisdn-linux.yaml:rm-work.yaml
 ```
 
 ## Limiting memory and CPU usage
@@ -79,7 +82,7 @@ you can limit the resources available to the build process by having
 kas-container pass additional options to `docker run`. For instance:
 
 ```shell
-kas-container --runtime-args "--cpus=14" --runtime-args "--memory=16g" \
+KAS_MACHINE=generic-x86-64 kas-container --runtime-args "--cpus=14" --runtime-args "--memory=16g" \
   --runtime-args "--memory-swap=20g" build bisdn-linux.yaml:ofdpa-gitlab.yaml
 ```
 
@@ -92,7 +95,7 @@ complaints that the authenticity of the host can't be established)
 and your ssh-agent (for authentication with gitlab.bisdn.de):
 
 ```shell
-kas-container --ssh-agent --ssh-dir ~/.ssh build bisdn-linux.yaml:ofdpa-gitlab.yaml
+KAS_MACHINE=generic-x86-64 kas-container --ssh-agent --ssh-dir ~/.ssh build bisdn-linux.yaml:ofdpa-gitlab.yaml
 ```
 
 ## Troubleshooting

--- a/README.md
+++ b/README.md
@@ -66,34 +66,26 @@ A single build requires about 100 GiB of disk space. The cache directories in
 
 ## Building a BISDN Linux image
 
-### x86_64 platforms
+BISDN Linux supports two different architectures: Broadcom XGS iProc (ARM), and
+Intel x86-64.
 
-The default image works on all x86_64 platforms supported by BISDN
-Linux. To build the image from the latest sources, clone this repo and
-run the following command in its root directory:
+To select the target machine for BISDN Linux, pass the appropriate name via
+the`KAS_MACHINE` environment variable:
+
+* `generic-armel-iproc` for devices based on Broadcom XGS iProc (Accton AS4610 series)
+* `generic-x86-64` for devices with an Intel x86 host CPU (all other supported devices)
+
+To build the image from the latest sources, clone this repo and run the
+following command in its root directory, e.g.:
 
 ```bash
-kas-container build bisdn-linux.yaml
+KAS_MACHINE=generic-x86-64 kas-container build bisdn-linux.yaml
 ```
 
 After the build process has finished, your image will be in
-`build/tmp/deploy/images/generic-x86-64/`. A symlink named
-`onie-bisdn-full-generic-x86-64.bin` will point to the actual image
-file named `onie-bisdn-full-generic-x86-64-<timestamp>.bin`.
-
-### ARM platforms (Edgecore AS4610)
-
-To build an image that works on all ARM platforms supported by BISDN Linux,
-run this command in the root of this repository:
-
-```bash
-KAS_MACHINE=generic-armel-iproc kas-container build bisdn-linux.yaml
-```
-
-After the build process finishes, your image will be in
-`build/tmp/deploy/images/generic-armel-iproc/`. A symlink named
-`onie-bisdn-full-generic-armel-iproc.bin` will point to the actual image
-file named `onie-bisdn-full-generic-armel-iproc-<timestamp>.bin`.
+`build/tmp/deploy/images/<KAS_MACHINE>/`. A symlink named
+`onie-bisdn-full-<KAS_MACHINE>.bin` will point to the actual image
+file named `onie-bisdn-full-<KAS_MACHINE>-<timestamp>.bin`.
 
 ## Installing a BISDN Linux image
 


### PR DESCRIPTION
We should not rely on any defaults, as they may change, so always be explicit about the machine to build for.