### PR TITLE
v4.x: add release script

### DIFF
--- a/conf/local.conf.sample
+++ b/conf/local.conf.sample
@@ -239,6 +239,9 @@ DL_DIR ?= "/tmp/downloads"
 # ccache is sharable between different builds, so move it to a common location.
 CCACHE_TOP_DIR ?= "/tmp/ccache"
 
+# To enable CVE checking, uncomment the following line
+#INHERIT += "cve-check"
+
 #INHERIT += "rm_work"
 #RM_WORK_EXCLUDE += "linux-yocto uboot"
 #BB_NUMBER_THREADS = "8"

--- a/scripts/changelog.sh
+++ b/scripts/changelog.sh
@@ -1,0 +1,285 @@
+#!/bin/bash
+#
+# changelog.sh - Generate a list of new commits between two releases
+#
+#
+# SPDX-License-Identifier: MPL-2.0
+#
+# (C) 2021-2023 BISDN GmbH
+
+set -e
+
+TOPDIR="$(git rev-parse --show-toplevel)"
+
+ONELINE_FORMAT_COMMIT='%C(auto)%h %s'
+ONELINE_FORMAT='%C(auto)%s'
+
+IGNORED_LAYERS=""
+
+while getopts 'cehi:n:o:p:vw:' c
+do
+	case "$c" in
+	c)
+		PRINT_COMMITS=1
+		;;
+	e)
+		PRINT_EMPTY=1
+		;;
+	h)
+		PRINT_HELP=1
+		;;
+	i)
+		IGNORED_LAYERS=$OPTARG
+		;;
+	n)
+		NEW_VERSION=$OPTARG
+		;;
+	o)
+		OLD_VERSION=$OPTARG
+		;;
+	p)
+		PREFIX=$OPTARG
+		;;
+	v)
+		PRINT_VERSIONS=1
+		;;
+	w)
+		WORKDIR=$OPTARG
+		;;
+	esac
+done
+
+shift $((OPTIND-1))
+OLD=$1
+NEW=$2
+
+# $1 list of packages in the image
+# $2 packages available and their versions
+collect_package_versions() {
+	local package_list pkg_name pkg_version depends_file
+	declare -n packages=$1
+	declare -n versions=$2
+
+	# BB_ENV_EXTRAWHITE was renamed to BB_ENV_PASSTHROUGH_ADDITIONS and
+	# bitbake will error out if the old one exists in the environment, so
+	# make sure that neither is set
+	unset BB_ENV_EXTRAWHITE
+	unset BB_ENV_PASSTHROUGH_ADDITIONS
+	rm -f conf/local.conf
+	rm -f conf/bblayers.conf
+	sed -i 's|^TMPDIR = .*|TMPDIR = "${TOPDIR}/tmp"|' conf/local.conf.sample
+	sed -i 's|^DL_DIR ?= .*|DL_DIR = "${TOPDIR}/dl"|' conf/local.conf.sample
+	sed -i 's|^SSTATE_DIR ?= .*|SSTATE_DIR = "${TOPDIR}/sstate-cache"|' conf/local.conf.sample
+	source ../oe-init-build-env . >&2
+	git checkout conf/local.conf.sample >&2
+	bitbake -g full >&2
+
+	# This is a list of recipe names, not (sub-)packages, but unless we
+	# also want to build an image, this is the closest we can get.
+	packages=$(grep -v -e '-native' pn-buildlist)
+	oIFS=$IFS
+	IFS="
+"
+	package_list=$(bitbake -s full)
+	for package in $package_list; do
+		pkg_name=$(echo $package | awk '{ print $1}')
+		pkg_version=$(echo $package | awk -F: '{print $2}')
+		versions[$pkg_name]=$pkg_version
+	done
+	IFS=$oIFS
+
+	# reset to initial state
+	unset BB_ENV_EXTRAWHITE
+	unset BB_ENV_PASSTHROUGH_ADDITIONS
+	rm -f conf/local.conf
+	rm -f conf/bblayers.conf
+}
+
+[ -n "$PRINT_HELP" -o -z "$OLD" -o -z "$NEW" ] && {
+	echo "Generate a full release changelog for BISDN Linux and write it to STDOUT"
+	echo ""
+	echo "Generates a list of new commits between two versions for all (default) projects"
+	echo "defined in the default.xml, separated by project name."
+	echo ""
+	echo "Usage: $0 [<options>] <oldbranch|oldtag> <newbranch|newtag>"
+	echo "  e.g. $0 v4.8.0 v4.9.0"
+	echo "Options:"
+	echo "  -c		print commit hashes"
+	echo "  -e		print repos without changes"
+	echo "  -h		print this help"
+	echo "  -i		comma separated list of layers to ignore"
+	echo "  -n <new>	set the name of the new version (default: <newbranch|newtag>)"
+	echo "  -o <new>	set the name of the old version (default: <oldbranch|oldtag>)"
+	echo "  -p <prefix>	prefix all changelog entries with <prefix> (e.g. ' - ')"
+	echo "  -v		also include a list of updated packages and their version changes"
+	echo "  -w <dir>	use <dir> as repo work dir (warning: will discard any changes!)"
+	exit 1
+}
+
+which repo &> /dev/null || {
+	echo "ERROR: no working repo utility found." >&2
+	exit 1
+}
+
+declare -A old_revs
+declare -A new_revs
+declare -A repos
+declare -A repo_paths
+declare -A old_versions
+declare -A new_versions
+
+# use WORKDIR if defined, else create a temporary directory
+if [ -z "$WORKDIR" ]; then
+	WORKDIR=$(mktemp -d)
+	# make sure we delete it again when we are finished
+	trap "rm -rf $WORKDIR" EXIT
+fi
+
+pushd "$WORKDIR" > /dev/null
+
+# repo requires tags to be passed as "refs/tags/<name>", anything else will be
+# be treated as a branch and repo tries to checkout refs/heads/<name>, which
+# will fail for tags. So check if $OLD is a tag and use the full path.
+TAG="$(git ls-remote --tags $TOPDIR $OLD | awk '{print $2}')"
+repo init -q -b ${TAG:-${OLD}}  -u $TOPDIR > /dev/null
+repo sync -q > /dev/null
+
+dirs=$(repo list -p)
+for dir in $dirs; do
+	pushd $dir > /dev/null
+	REV=$(git rev-parse HEAD)
+	popd > /dev/null
+	layer=$(basename $dir)
+	if echo $IGNORED_LAYERS | grep -q -P "(?<![\w-])$layer(?![\w-])"; then
+		continue
+	fi
+	old_revs[$layer]=$REV
+	repos[$layer]=1
+done
+
+if [ -n "$PRINT_VERSIONS" ]; then
+	pushd $(repo list -p | grep 'build-') > /dev/null
+	collect_package_versions old_packages old_versions
+	popd > /dev/null
+fi
+
+# As with $OLD, we need to use the full path if $NEW is a tag.
+TAG="$(git ls-remote --tags $TOPDIR $NEW | awk '{print $2}')"
+repo init -q -b ${TAG:-${NEW}} > /dev/null
+repo sync -q --force-sync > /dev/null
+
+dirs=$(repo list -p)
+for dir in $dirs; do
+	pushd "$dir" > /dev/null
+	REV=$(git rev-parse HEAD)
+	popd > /dev/null
+	layer=$(basename "$dir")
+
+	# we cannot use -F, as -F considers dashes as a word delimiter, but
+	# layernames use them (e.g. meta-cloud-services).
+	# So use a handcrafted regex that only considers whitespaces.
+	if echo $IGNORED_LAYERS | grep -q -P "(?<![\w-])$layer(?![\w-])"; then
+		continue
+	fi
+	new_revs[$layer]=$REV
+	repos[$layer]=1
+	repo_paths[$layer]=$dir
+done
+
+if [ -n "$PRINT_VERSIONS" ]; then
+	pushd $(repo list -p | grep 'build-') > /dev/null
+	collect_package_versions new_packages new_versions
+	popd > /dev/null
+fi
+
+repo_dirs=$(echo ${!repos[@]} | tr ' ' '\n' | sort | tr '\n' ' ')
+
+if [ -n "$PRINT_VERSIONS" ]; then
+	packages=$(echo $old_packages $new_packages | tr '"' ' ' | tr ' ' '\n' | sort -u | tr '\n' ' ')
+	echo -e "\nUpdated packages:"
+	for package in $packages; do
+		old_version=$(echo ${old_versions[$package]})
+		new_version=$(echo ${new_versions[$package]})
+		[ "$old_version" = "$new_version" ] && continue
+		if [ -z "$old_version" ]; then
+			bump="NEW"
+		elif [ -z "$new_version" ]; then
+			bump="REMOVED"
+		else
+			bump="$old_version => $new_version"
+		fi
+
+		echo "$package ($bump)"
+	done
+fi
+
+echo -e "Changes between ${OLD_VERSION:-${OLD}} and ${NEW_VERSION:-${NEW}}:\n"
+
+for dir in $repo_dirs; do
+	rev_old=${old_revs[$dir]}
+	rev_new=${new_revs[$dir]}
+
+	if [ -n "$rev_old" -a -n "$rev_new" ]; then
+		pushd ${repo_paths[$dir]} > /dev/null
+
+		if ! git cat-file -t $rev_old > /dev/null; then
+			# repo changed, and revision does not exist in new repo
+			echo "$dir: $OLD's revision not found in git repo, skipping ..." >&2
+			popd > /dev/null
+			continue
+		fi
+
+		MERGE_BASE=$(git merge-base $rev_old $rev_new)
+		if [ "$MERGE_BASE" != "$rev_old" ]; then
+			# get a list of commits, then iterate over them and
+			# remove any commits with the same subject in both
+			# branches to remove duplicates.
+
+			changes_old=$(git log --format="$ONELINE_FORMAT_COMMIT" --no-merges $MERGE_BASE..$rev_old)
+			changes_new=$(git log --format="$ONELINE_FORMAT_COMMIT" --no-merges $MERGE_BASE..$rev_new)
+			changes=""
+			oIFS=$IFS
+			IFS="
+"
+			for change in $changes_new; do
+				TEXT=${change#* }
+				SKIP=
+				for oldchange in $changes_old; do
+					OLD_TEXT=${oldchange#* }
+					if [ "$TEXT" = "$OLD_TEXT" ]; then
+						SKIP=1
+						break
+					fi
+				done
+				[ -n "$SKIP" ] && continue
+
+				[ -n "$changes" ] && changes="$changes
+"
+				 [ -n "$PRINT_COMMITS" ] && TEXT=$change
+				changes="${changes}${PREFIX}${TEXT}"
+			done
+			IFS=$oIFS
+		else
+			if [ -n "$PRINT_COMMITS" ]; then
+				FORMAT="$ONELINE_FORMAT_COMMIT"
+			else
+				FORMAT="$ONELINE_FORMAT"
+			fi
+
+			changes=$(git log --format="$PREFIX$FORMAT" --no-merges $rev_old..$rev_new)
+		fi
+		popd > /dev/null
+		if [ -n "$changes" ]; then
+			echo "$dir:"
+			echo -e "$changes\n"
+		elif [ -n "$PRINT_EMPTY" ]; then
+			echo "$dir:"
+			echo -e "(no changes)\n"
+		fi
+	elif [ -z "$rev_old" ]; then
+		echo -e "$dir (NEW)\n"
+	else
+		echo -e "$dir (REMOVED)\n"
+	fi
+done
+popd > /dev/null

--- a/scripts/prepare_release.sh
+++ b/scripts/prepare_release.sh
@@ -3,7 +3,7 @@
 set -e
 
 TOPDIR="$(git rev-parse --show-toplevel)"
-BASEBRANCH="main"
+BASEBRANCH="v4.x"
 BRANCHPREFIX="release"
 UPDATE=0
 

--- a/scripts/prepare_release.sh
+++ b/scripts/prepare_release.sh
@@ -82,7 +82,7 @@ sanity_check_meta-ofdpa() {
 generate_changelog() {
 	echo "Generating changelog (this may take a while) ..."
 
-	$TOPDIR/scripts/changelog.sh -w $WORKDIR -n $NEW -i meta-ofdpa-closed $OLD "$RELEASE_BRANCH" > changelog.txt
+	$TOPDIR/scripts/changelog.sh -f -w $WORKDIR -n $NEW -i meta-ofdpa-closed $OLD "$RELEASE_BRANCH" > changelog.txt
 	git add changelog.txt
 
 	if [ "$UPDATE" -eq 1 ]; then

--- a/scripts/prepare_release.sh
+++ b/scripts/prepare_release.sh
@@ -1,0 +1,209 @@
+#!/bin/bash
+
+set -e
+
+TOPDIR="$(git rev-parse --show-toplevel)"
+BASEBRANCH="main"
+BRANCHPREFIX="release"
+UPDATE=0
+
+generate_default_xml() {
+	if [ -n "$URI" ]; then
+		echo "Copying default.xml ..."
+		curl "$URI" -o $TOPDIR/default.xml
+		SOURCE=$URI
+	else
+		echo "Generating default.xml ..."
+		pushd $WORKDIR > /dev/null
+		repo init -q -b $BASEBRANCH -u $TOPDIR -g all,ofdpa-gitlab
+		repo sync
+		repo manifest --revision-as-HEAD -o $TOPDIR/default.xml
+		popd > /dev/null
+		SOURCE="current $BASEBRANCH branch"
+	fi
+
+	if [ "$UPDATE" -eq 1 ]; then
+		MSG="default.xml: update release revisions
+
+Upate release revisions in default.xml based on $SOURCE."
+	else
+		MSG="default.xml: set release revisions
+
+Set release revisions in default.xml based on $SOURCE."
+	fi
+
+	git commit -s -m "$MSG" default.xml
+}
+
+# Check that the top commits for OF-DPA and ofdpa-grpc recipes are identical
+# between open and closed repositories by comparing the subjects.
+#
+# If there is a difference, we must have forgotten to push an update to the
+# open repository.
+sanity_check_meta-ofdpa() {
+	echo "Ensuring public and closed meta-ofdpa are in sync ..."
+	local abort=0
+	pushd $WORKDIR > /dev/null
+	repo init -q -b $RELEASE_BRANCH -u $TOPDIR -g all,ofdpa-gitlab
+	repo sync
+
+	pushd poky/meta-ofdpa > /dev/null
+	OFDPA_OPEN_TOP="$(git log --no-merges --pretty='format:%s' -1 recipes-ofpda/ofdpa/ofdpa_*.bb)"
+	OFDPA_GRPC_OPEN_TOP="$(git log --no-merges --pretty='format:%s' -1 recipes-extended/ofdpa-grpc/ofdpa-grpc_*.bb)"
+	popd > /dev/null
+	pushd poky/meta-ofdpa-closed > /dev/null
+	OFDPA_CLOSED_TOP="$(git log --no-merges --pretty='format:%s' -1 recipes-ofpda/ofdpa/ofdpa_*.bb)"
+	OFDPA_GRPC_CLOSED_TOP="$(git log --no-merges --pretty='format:%s' -1 recipes-extended/ofdpa-grpc/ofdpa-grpc_*.bb)"
+	popd > /dev/null
+
+	popd > /dev/null
+
+	if [ "$OFDPA_OPEN_TOP" != "$OFDPA_CLOSED_TOP" ]; then
+		echo "meta-ofdpa [gitlab] OF-DPA recipe has unpublished changes!" >&2
+
+		echo " meta-ofdpa [github] OF-DPA recipe HEAD: $OFDPA_OPEN_TOP" >&2
+		echo " meta-ofdpa [gitlab] OF-DPA recipe HEAD: $OFDPA_CLOSED_TOP" >&2
+		abort=1
+	fi
+
+	if [ "$OFDPA_GRPC_OPEN_TOP" != "$OFDPA_GRPC_CLOSED_TOP" ]; then
+		echo "meta-ofdpa [gitlab] ofdpa-grpc recipe has unpublished changes!" >&2
+
+		echo " meta-ofdpa [github] ofdpa-grpc recipe HEAD: $OFDPA_GRPC_OPEN_TOP" >&2
+		echo " meta-ofdpa [gitlab] ofdpa-grpc recipe HEAD: $OFDPA_GRPC_CLOSED_TOP" >&2
+		abort=1
+	fi
+
+	if [ "$abort" = "1" ]; then
+		exit 1
+	fi
+}
+
+generate_changelog() {
+	echo "Generating changelog (this may take a while) ..."
+
+	$TOPDIR/scripts/changelog.sh -w $WORKDIR -n $NEW -i meta-ofdpa-closed $OLD "$RELEASE_BRANCH" > changelog.txt
+	git add changelog.txt
+
+	if [ "$UPDATE" -eq 1 ]; then
+		MSG="update changelog.txt"
+	else
+		MSG="add changelog.txt"
+	fi
+
+	git commit -s -m "$MSG" changelog.txt
+}
+
+set_feed_uri_prefix() {
+	echo "Setting FEEDURIPREFIX to release value ..."
+	echo 'FEEDURIPREFIX = "pub/onie/${MACHINE}/packages-v${DISTRO_VERSION}"' >> conf/local.conf.sample
+	git commit -s -m "conf: set release FEEDURIPREFIX
+
+Set the FEEDURIPREFIX to the release path." conf/local.conf.sample
+}
+
+update_default_xml() {
+	echo "Updating default.xml to point commit with the changelog.txt ..."
+	# update default.xml so that the bisdn-linux checkout will be include
+	# the changelog.txt and release FEEDURIPREFIX
+
+	HEAD_COMMIT="$(git rev-parse HEAD)"
+	xmlstarlet edit --inplace \
+	       --update "/manifest/project[@name='bisdn/bisdn-linux.git']/@upstream" --value "$RELEASE_BRANCH" \
+	       --update "/manifest/project[@name='bisdn/bisdn-linux.git']/@dest-branch" --value "$RELEASE_BRANCH" \
+	       --update "/manifest/project[@name='bisdn/bisdn-linux.git']/@revision" --value "$HEAD_COMMIT" \
+	       default.xml
+
+	if [ "$UPDATE" -eq 1 ]; then
+		MSG="default.xml: update build-bisdn-linux to new revision
+
+Update build-bisdn-linux to include the updated changelog.txt.
+"
+	else
+		MSG="default.xml: switch build-bisdn-linux to release branch
+
+Update build-bisdn-linux to include the generated changelog.txt and release
+FEEDURIPREFIX.
+"
+	fi
+	git commit -s -m "$MSG" default.xml
+}
+
+print_help() {
+	echo "Prepare or update a release branch with fixed revisions and release configuration"
+	echo ""
+	echo "Prepares a release branch named release/<new_version> with the configuration"
+	echo "updated for a release, a default.xml with fixed revisions and a changelog.txt"
+	echo "based on the passed <old_version>."
+	echo "Revisions taken either from current $BASEBRANCH or a default.xml passed via URI"
+	echo "argument."
+	echo "If the release branch already exists, update default.xml and changelog.txt only."
+	echo ""
+	echo "Usage:"
+	echo "$0 <old_version> <new_version> [URI]"
+	exit 1
+}
+
+OLD=$1
+NEW=$2
+URI=$3
+
+if [ -z "$OLD" -o -z "$NEW" ]; then
+	print_help
+fi
+
+REQUIRED_BINARIES="curl git repo xmlstarlet"
+FAILED=0
+
+for binary in $REQUIRED_BINARIES; do
+	if ! command -v $binary > /dev/null; then
+		echo "ERROR: '$binary' was not found in path." >&2
+		FAILED=1
+	fi
+done
+
+if [ "$FAILED" != "0" ]; then
+	echo "ERROR: Some required programs are not available. Please install and try again." >&2
+	exit 1
+fi
+
+RELEASE_BRANCH="$BRANCHPREFIX/$NEW"
+WORKDIR=$(mktemp -d)
+# make sure we delete it again
+trap "rm -rf $WORKDIR" EXIT
+
+echo "Preparing branch $RELEASE_BRANCH"
+
+pushd $TOPDIR
+
+# make sure we are up to date
+git fetch
+# if $OLD is a branch, make sure $OLD exists and is up to date
+if ! git rev-parse --verify --quiet --tags "refs/tags/$OLD" > /dev/null; then
+	git branch -f $OLD origin/$OLD
+fi
+
+if git rev-parse --verify --quiet "refs/heads/$RELEASE_BRANCH" > /dev/null; then
+	# branch already exists, so only update it
+	UPDATE=1
+	git checkout "$RELEASE_BRANCH"
+else
+	# this is a new branch, so create it and set it to release
+	git switch -c "$RELEASE_BRANCH" $BASEBRANCH
+	set_feed_uri_prefix
+fi
+
+generate_default_xml
+sanity_check_meta-ofdpa
+generate_changelog
+update_default_xml
+
+popd
+
+echo "Release branch successfully prepared/updated as $RELEASE_BRANCH
+
+Please review and directly push if acceptable.
+
+WARNING: Do *NOT* create a pull request, as pull requests will rewrite commits
+when merged, breaking the bisdn-linux reference in default.xml.
+"


### PR DESCRIPTION
To make preparing a v4.x release easier as well, backport the release script and update its basebranch to 4.x.