### PR TITLE
convert.sh: check for .yaml, not .yml

### DIFF
--- a/scripts/convert.sh
+++ b/scripts/convert.sh
@@ -81,7 +81,7 @@ write_manifest() {
 }
 
 case "$1" in
-	*.yml)
+	*.yaml)
 		read_lockfile $1
 		;;
 	*.xml)
@@ -93,7 +93,7 @@ case "$1" in
 esac
 
 case "$2" in
-	*.yml)
+	*.yaml)
 		write_lockfile $2
 		;;
 	*.xml)


### PR DESCRIPTION
Our lockfiles and kas configs use .yaml, not .yml, so we need to check for a .yaml suffix.

Fixes release config generation based on kas lock file.

Fixes: 92fa3f65205d ("scripts: add a proof of concept conversion script")