### PR TITLE
prepare_release.sh: add check that DISTRO_VERSION matches the release name

### DIFF
--- a/scripts/prepare_release.sh
+++ b/scripts/prepare_release.sh
@@ -52,6 +52,13 @@ Set release revisions in in bidn-linux.lock.yaml and default.xml based on $SOURC
 	git commit -s -m "$MSG" default.xml bisdn-linux.lock.yaml
 }
 
+prepare_workdir() {
+	pushd $WORKDIR > /dev/null
+	repo init -q -b $RELEASE_BRANCH -u $TOPDIR -g all,ofdpa-gitlab
+	repo sync
+	popd > /dev/null
+}
+
 # Check that the top commits for OF-DPA and ofdpa-grpc recipes are identical
 # between open and closed repositories by comparing the subjects.
 #
@@ -61,8 +68,6 @@ sanity_check_meta-ofdpa() {
 	echo "Ensuring public and closed meta-ofdpa are in sync ..."
 	local abort=0
 	pushd $WORKDIR > /dev/null
-	repo init -q -b $RELEASE_BRANCH -u $TOPDIR -g all,ofdpa-gitlab
-	repo sync
 
 	pushd poky/meta-ofdpa > /dev/null
 	OFDPA_OPEN_TOP="$(git log --no-merges --pretty='format:%s' -1 recipes-ofpda/ofdpa/ofdpa_*.bb)"
@@ -214,6 +219,7 @@ else
 fi
 
 lock_revisions
+prepare_workdir
 sanity_check_meta-ofdpa
 generate_changelog
 update_default_xml

--- a/scripts/prepare_release.sh
+++ b/scripts/prepare_release.sh
@@ -101,6 +101,22 @@ sanity_check_meta-ofdpa() {
 	fi
 }
 
+# check that DISTRO_VERSION matches the release version
+check_version() {
+	local distro_version
+
+	distro_version=$(grep '^DISTRO_VERSION' $WORKDIR/poky/meta-bisdn-linux/conf/distro/bisdn-linux.conf)
+
+	# extract value of 'DISTRO_VERSION = "X.Y.Z"'
+	distro_version=${source_version#*\"}
+	distro_version=${source_version%\"*}
+
+	if [ "v$source_version" != "$NEW" ]; then
+		echo "DISTRO_VERSION does not match release version (expected \"${NEW#v}\", got \"$distro_version\")" >&2
+		exit 1
+	fi
+}
+
 generate_changelog() {
 	echo "Generating changelog (this may take a while) ..."
 
@@ -221,6 +237,7 @@ fi
 lock_revisions
 prepare_workdir
 sanity_check_meta-ofdpa
+check_version
 generate_changelog
 update_default_xml
 


### PR DESCRIPTION
Since we managed to do a release that had an invalid version, let's add a check for the release script to check that `DISTRO_VERSION` is set to the version for which we are preparing a release.