### PR TITLE
prepare_release: fix version check

### DIFF
--- a/scripts/prepare_release.sh
+++ b/scripts/prepare_release.sh
@@ -108,10 +108,10 @@ check_version() {
 	distro_version=$(grep '^DISTRO_VERSION' $WORKDIR/poky/meta-bisdn-linux/conf/distro/bisdn-linux.conf)
 
 	# extract value of 'DISTRO_VERSION = "X.Y.Z"'
-	distro_version=${source_version#*\"}
-	distro_version=${source_version%\"*}
+	distro_version=${distro_version#*\"}
+	distro_version=${distro_version%\"*}
 
-	if [ "v$source_version" != "$NEW" ]; then
+	if [ "v$distro_version" != "$NEW" ]; then
 		echo "DISTRO_VERSION does not match release version (expected \"${NEW#v}\", got \"$distro_version\")" >&2
 		exit 1
 	fi


### PR DESCRIPTION
While refactoring and renaming the variable some places were missed, and the check then didn't work. Fix this by consistently using the correct variable.

Fixes: 1e28392ab39f ("prepare_release: add a check that DISTRO_VERSION is correct")