### PR TITLE
convert.sh: use remote bisdn-linux HEAD on conversion from kas to repo

### DIFF
--- a/scripts/convert.sh
+++ b/scripts/convert.sh
@@ -54,9 +54,15 @@ read_manifest() {
 }
 
 write_manifest() {
-	# KAS does not reference this repository, so take the HEAD revision
+	# KAS does not reference this repository, so take the HEAD revision of
+	# the remote branch, or main if the release branch does not exist yet.
 	if [ -z "${REPOS["bisdn-linux"]}" ]; then
-		REPOS["bisdn-linux"]="$(git rev-parse HEAD)"
+		BRANCH="$(git branch --show-current)"
+		if git ls-remote --exit-code origin $BRANCH >/dev/null; then
+			REPOS["bisdn-linux"]="$(git rev-parse origin/$BRANCH)"
+		else
+			REPOS["bisdn-linux"]="$(git rev-parse origin/main)"
+		fi
 	fi
 
 	if [ "$1" == "default.xml" ]; then


### PR DESCRIPTION
The changelog script currently relies on the generated default.xml's revisions being present in the upstream repository, but the very first commit on creating a release branch is to update the FEEDURI_PREFIX to the release one.

If we then try to generate a default.xml using the HEAD revision, the bisdn-linux commit hash is a local one.

This then breaks the script when it tries to generate a changelog and tries to checkout the new version, where bisdn-linux references a commit not existing yet in the upstream repo.

Fix this by instead using the HEAD revision of the remote's current branch, or main if there isn't one.

Fixes: 92fa3f65205d ("scripts: add a proof of concept conversion script")