### PR TITLE
bisdn-linux.yaml: pass BUILD_ID on to env

### DIFF
--- a/bisdn-linux.yaml
+++ b/bisdn-linux.yaml
@@ -7,6 +7,7 @@ target: full
 
 env:
     # Export variables (if set) to bitbake via BB_ENV_PASSTHROUGH_ADDITIONS
+    BUILD_ID: null
     CCACHE_TOP_DIR: null
     FEEDURIPREFIX: null
 


### PR DESCRIPTION
In order to make the BUILD_ID reproducible, allow it being set via environment instead of always using DATETIME.