### PR TITLE
changelog.sh: do not check every recipe for CVEs

### DIFF
--- a/scripts/changelog.sh
+++ b/scripts/changelog.sh
@@ -106,12 +106,15 @@ collect_bitbake_info() {
 	oIFS=$IFS
 	IFS="
 "
-	package_list=$(bitbake -s full)
+	package_list=$(bitbake -s)
 	for package in $package_list; do
 		pkg_name=$(echo $package | awk '{ print $1}')
 		pkg_version=$(echo $package | awk -F: '{print $2}')
 		versions[$pkg_name]=$pkg_version
-		if [ -n "$PRINT_CVE_FIXES" ]; then
+	done
+
+	if [ -n "$PRINT_CVE_FIXES" ]; then
+		for pkg_name in $packages; do
 			# JSON format example:
 			# {
 			#   "version": "1",
@@ -143,8 +146,9 @@ collect_bitbake_info() {
 			# collect all issue ids with status 'Unpatched' for this package:
 			cve_list=$(jq -r '.package[] | select (.name == "'${pkg_name}'") | .issue[] | select ( .status == "Unpatched" ) | { id } | join(" ")' $cve_file)
 			cve_issues[$pkg_name]="$cve_list"
-		fi
-	done
+		done
+	fi
+
 	IFS=$oIFS
 
 	# reset to initial state


### PR DESCRIPTION
"bitbake -s" actually does not take any arguments, and prints the versions of all recipes available. This is a much larger list than the recipes actually used for building the image.

Since the cve report contains only CVEs for recipes used in the image, this causes a lot of checks for CVEs for which the answer will always be empty.

So instead iterate over $packages which only contains the recipe names of recipes included in the image. This significantly speeds up the CVE collection.

In a non-scientific test this sped up collecting the package versions and CVEs of one release from ~16 minutes to ~1 minute, so it should reduce generating a changelog with CVEs by about half an hour.