### PR TITLE
v5.x: switch our branches from main to v5.x

### DIFF
--- a/bisdn-linux.yaml
+++ b/bisdn-linux.yaml
@@ -65,15 +65,15 @@ repos:
     # open source BISDN layers
     meta-bisdn-linux:
         url: "https://github.com/bisdn/meta-bisdn-linux.git"
-        branch: "main"
+        branch: "v5.x"
         path: "sources/meta-bisdn-linux"
 
     meta-ofdpa:
         url: "https://github.com/bisdn/meta-ofdpa.git"
-        branch: "main"
+        branch: "v5.x"
         path: "sources/meta-ofdpa"
 
     meta-open-network-linux:
         url: "https://github.com/bisdn/meta-open-network-linux.git"
-        branch: "main"
+        branch: "v5.x"
         path: "sources/meta-open-network-linux"

--- a/default.xml
+++ b/default.xml
@@ -11,10 +11,10 @@
   <!-- open embedded layer -->
   <project name="meta-openembedded" path="poky/meta-openembedded" remote="oe" revision="kirkstone"/>
   <!-- open source bisdn layers -->
-  <project name="bisdn/bisdn-linux.git" path="poky/build-bisdn-linux" remote="github" revision="main"/>
-  <project name="bisdn/meta-bisdn-linux.git" path="poky/meta-bisdn-linux" remote="github" revision="main"/>
-  <project name="bisdn/meta-ofdpa.git" path="poky/meta-ofdpa" remote="github" revision="main"/>
-  <project name="bisdn/meta-open-network-linux.git" path="poky/meta-open-network-linux" remote="github" revision="main"/>
+  <project name="bisdn/bisdn-linux.git" path="poky/build-bisdn-linux" remote="github" revision="v5.x"/>
+  <project name="bisdn/meta-bisdn-linux.git" path="poky/meta-bisdn-linux" remote="github" revision="v5.x"/>
+  <project name="bisdn/meta-ofdpa.git" path="poky/meta-ofdpa" remote="github" revision="v5.x"/>
+  <project name="bisdn/meta-open-network-linux.git" path="poky/meta-open-network-linux" remote="github" revision="v5.x"/>
   <!-- closed source bisdn layers -->
-  <project name="yocto-meta-layers/meta-ofdpa.git" path="poky/meta-ofdpa-closed" remote="gitlab" revision="main" groups="notdefault,ofdpa-gitlab"/>
+  <project name="yocto-meta-layers/meta-ofdpa.git" path="poky/meta-ofdpa-closed" remote="gitlab" revision="v5.x" groups="notdefault,ofdpa-gitlab"/>
 </manifest>

--- a/ofdpa-gitlab.yaml
+++ b/ofdpa-gitlab.yaml
@@ -4,5 +4,5 @@ header:
 repos:
     meta-ofdpa-closed:
         url: "ssh://git@gitlab.bisdn.de/yocto-meta-layers/meta-ofdpa.git"
-        branch: "main"
+        branch: "v5.x"
         path: "sources/meta-ofdpa-closed"

--- a/scripts/prepare_release.sh
+++ b/scripts/prepare_release.sh
@@ -3,7 +3,7 @@
 set -e
 
 TOPDIR="$(git rev-parse --show-toplevel)"
-BASEBRANCH="main"
+BASEBRANCH="v5.x"
 BRANCHPREFIX="release"
 UPDATE=0
 


### PR DESCRIPTION
In preparation for the next major BISDN Linux version, move v5.x to its own branches.