### PR TITLE
scripts/convert.sh: set bisdn-linux base branch to v5.x

### DIFF
--- a/scripts/convert.sh
+++ b/scripts/convert.sh
@@ -55,13 +55,13 @@ read_manifest() {
 
 write_manifest() {
 	# KAS does not reference this repository, so take the HEAD revision of
-	# the remote branch, or main if the release branch does not exist yet.
+	# the remote branch, or v5.x if the release branch does not exist yet.
 	if [ -z "${REPOS["bisdn-linux"]}" ]; then
 		BRANCH="$(git branch --show-current)"
 		if git ls-remote --exit-code origin $BRANCH >/dev/null; then
 			REPOS["bisdn-linux"]="$(git rev-parse origin/$BRANCH)"
 		else
-			REPOS["bisdn-linux"]="$(git rev-parse origin/main)"
+			REPOS["bisdn-linux"]="$(git rev-parse origin/v5.x)"
 		fi
 	fi
 


### PR DESCRIPTION
When generating a changelog for v5.x using a kas lock file as base, we don't have a bisdn-linux repository base commit, so we take the head of the v5.x branch, not main branch.