### PR TITLE
workflow: fix builds with scarthgap

### DIFF
--- a/.github/workflows/build-bisdn-linux.yml
+++ b/.github/workflows/build-bisdn-linux.yml
@@ -108,7 +108,7 @@ jobs:
           echo "##############################################################"
           du -ms "$SSTATE_CACHE_DIR"
           echo "Removing duplicates in sstate-cache."
-          ./sources/poky/scripts/sstate-cache-management.sh \
+          ./sources/poky/scripts/sstate-cache-management.py \
             --cache-dir="$SSTATE_CACHE_DIR" --remove-duplicated --yes
           echo "##############################################################"
           du -ms "$SSTATE_CACHE_DIR"

--- a/.github/workflows/build-bisdn-linux.yml
+++ b/.github/workflows/build-bisdn-linux.yml
@@ -12,6 +12,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 420
 
     strategy:
       matrix:


### PR DESCRIPTION
Fix two issues causing our build CI fail since the switch to scarthgap:

1. In newer Yocto versions sstate-cache-management.sh was rewritten in python, so check for sstate-cache-management.py first and use that if it exists.
2. The armel-iproc build could take more than 6 hours, running into the default job timeout of 360 minutes (x86 is at ~5:50 or so). Increase the limit by another 60 minutes to allow it to pass.