### PR TITLE
add meta-lts-collab layer

### DIFF
--- a/bisdn-linux.yaml
+++ b/bisdn-linux.yaml
@@ -62,6 +62,12 @@ repos:
             meta-python:
             meta-webserver:
 
+    # community fixes
+    meta-lts-collab:
+        url: "https://github.com/garmin/meta-lts-collab.git"
+        branch: "kirkstone"
+        path: "sources/meta-lts-collab"
+
     # open source BISDN layers
     meta-bisdn-linux:
         url: "https://github.com/bisdn/meta-bisdn-linux.git"

--- a/default.xml
+++ b/default.xml
@@ -10,6 +10,8 @@
   <project name="poky" path="poky" remote="yocto" revision="kirkstone"/>
   <!-- open embedded layer -->
   <project name="meta-openembedded" path="poky/meta-openembedded" remote="oe" revision="kirkstone"/>
+  <!-- community fixes -->
+  <project name="https://github.com/garmin/meta-lts-collab.git" path="poky/meta-lts-collab" remote="github" revision="kirkstone"/>
   <!-- open source bisdn layers -->
   <project name="bisdn/bisdn-linux.git" path="poky/build-bisdn-linux" remote="github" revision="v5.x"/>
   <project name="bisdn/meta-bisdn-linux.git" path="poky/meta-bisdn-linux" remote="github" revision="v5.x"/>


### PR DESCRIPTION
Now that kirkstone is EOL, add the meta-lts-collab layer for providing additional fixes for kirkstone.