### PR TITLE
Use https for Yocto and Open Embedded repos

### DIFF
--- a/bisdn-linux.yaml
+++ b/bisdn-linux.yaml
@@ -28,7 +28,7 @@ local_conf_header:
 
 repos:
     poky:
-        url: "git://git.yoctoproject.org/poky"
+        url: "https://git.yoctoproject.org/poky"
         branch: "scarthgap"
         path: "sources/poky"
         layers:
@@ -38,7 +38,7 @@ repos:
 
     # additional yocto layers
     meta-cloud-services:
-        url: "git://git.yoctoproject.org/meta-cloud-services"
+        url: "https://git.yoctoproject.org/meta-cloud-services"
         branch: "scarthgap"
         path: "sources/meta-cloud-services"
         layers:
@@ -46,13 +46,13 @@ repos:
             meta-openstack:
 
     meta-virtualization:
-        url: "git://git.yoctoproject.org/meta-virtualization"
+        url: "https://git.yoctoproject.org/meta-virtualization"
         branch: "scarthgap"
         path: "sources/meta-virtualization"
 
     # open embedded layers
     meta-openembedded:
-        url: "git://git.openembedded.org/meta-openembedded"
+        url: "https://git.openembedded.org/meta-openembedded"
         branch: "scarthgap"
         path: "sources/meta-openembedded"
         layers:

--- a/default.xml
+++ b/default.xml
@@ -2,8 +2,8 @@
 <manifest>
   <remote name="github" fetch="https://github.com/" />
   <remote name="gitlab" fetch="ssh://git@gitlab.bisdn.de/" />
-  <remote name="oe" fetch="git://git.openembedded.org/" />
-  <remote name="yocto" fetch="git://git.yoctoproject.org/" />
+  <remote name="oe" fetch="https://git.openembedded.org/" />
+  <remote name="yocto" fetch="https://git.yoctoproject.org/" />
   <!-- yocto layer -->
   <project name="meta-cloud-services" path="poky/meta-cloud-services" remote="yocto" revision="scarthgap"/>
   <project name="meta-virtualization" path="poky/meta-virtualization" remote="yocto" revision="scarthgap"/>


### PR DESCRIPTION
> Action Required: Please update all your git remotes to use the https:// protocol. The correct remote URLs are currently listed on [git.yoctoproject.org](http://git.yoctoproject.org/) and [git.openembedded.org](http://git.openembedded.org/)

https://lists.yoctoproject.org/g/yocto-infrastructure/topic/git_service_protocol_change/118721034

This is currently breaking automated builds.