### PR TITLE
create an SBOM snippet

### DIFF
--- a/sbom.yaml
+++ b/sbom.yaml
@@ -1,0 +1,10 @@
+header:
+    version: 14
+
+local_conf_header:
+    spdx-sbom-conf: |
+        INHERIT:remove = " create-spdx"
+        INHERIT += " vex"
+        INHERIT += " create-spdx-3.0"
+        SPDX_INCLUDE_COMPILED_SOURCES:pn-linux-yocto-onl = "1"
+        SPDX_PRETTY = "1"


### PR DESCRIPTION
Create a kas snippet for creating an SBOM while building.

Enable pretty formatting to make it easier to inspect with a text editor.

To allow better vulnerability handling, also include VEX information in the SDPX SBOM as well as information about compiled sources of the kernel.